### PR TITLE
Adds ReadString

### DIFF
--- a/osrelease_test.go
+++ b/osrelease_test.go
@@ -2,19 +2,13 @@ package osrelease
 
 import (
 	"fmt"
+	"io/ioutil"
 	"strconv"
 	"testing"
 )
 
-func TestReadNoFile(t *testing.T) {
-	_, err := ReadFile("test/nosuchfile")
-	if err == nil {
-		t.Errorf("Read() on non-existant file returned nil, should not be nil")
-	}
-}
-
-func TestReadFile(t *testing.T) {
-	expectedResults := map[int]map[string]string{
+func expectedResults() {
+	return map[int]map[string]string{
 		1: {
 			"NAME":        "void",
 			"ID":          "void",
@@ -65,12 +59,44 @@ func TestReadFile(t *testing.T) {
 			"ANSI_COLOR":  "",
 		},
 	}
+}
 
-	for test := 1; test <= len(expectedResults); test++ {
+func TestReadNoFile(t *testing.T) {
+	_, err := ReadFile("test/nosuchfile")
+	if err == nil {
+		t.Errorf("Read() on non-existant file returned nil, should not be nil")
+	}
+}
+
+func TestReadFile(t *testing.T) {
+
+	for test := 1; test <= len(expectedResults()); test++ {
 		filename := "test/os-release." + strconv.Itoa(test)
 		osrelease, err := ReadFile(filename)
 		if err != nil {
 			t.Fatalf("Error reading test file '%v': %v", filename, err)
+		} else {
+			for key, value := range expectedResults[test] {
+				if osrelease[key] != value {
+					t.Errorf("In file 'test/os-release.%v', Read() returned '%v' = '%v', should be '%v'", test, key, osrelease[key], value)
+				}
+			}
+		}
+	}
+}
+
+func TestReadString(t *testing.T) {
+	for test := 1; test <= len(expectedResults()); test++ {
+		filename := "test/os-release." + strconv.Itoa(test)
+		bytes, err := ioutil.ReadFile(filename)
+		if err != nil {
+			t.Fatalf("Error reading test file '%v': %v", filename, err)
+		}
+
+		osrelease, err := ReadString(string(bytes))
+
+		if err != nil {
+			t.Fatalf("Error parsing content of '%v': %v", filename, err)
 		} else {
 			for key, value := range expectedResults[test] {
 				if osrelease[key] != value {

--- a/osrelease_test.go
+++ b/osrelease_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func expectedResults() {
+func expectedResults() map[int]map[string]string {
 	return map[int]map[string]string{
 		1: {
 			"NAME":        "void",
@@ -69,14 +69,15 @@ func TestReadNoFile(t *testing.T) {
 }
 
 func TestReadFile(t *testing.T) {
+	results := expectedResults()
 
-	for test := 1; test <= len(expectedResults()); test++ {
+	for test := 1; test <= len(results); test++ {
 		filename := "test/os-release." + strconv.Itoa(test)
 		osrelease, err := ReadFile(filename)
 		if err != nil {
 			t.Fatalf("Error reading test file '%v': %v", filename, err)
 		} else {
-			for key, value := range expectedResults[test] {
+			for key, value := range results[test] {
 				if osrelease[key] != value {
 					t.Errorf("In file 'test/os-release.%v', Read() returned '%v' = '%v', should be '%v'", test, key, osrelease[key], value)
 				}
@@ -86,7 +87,9 @@ func TestReadFile(t *testing.T) {
 }
 
 func TestReadString(t *testing.T) {
-	for test := 1; test <= len(expectedResults()); test++ {
+	results := expectedResults()
+
+	for test := 1; test <= len(results); test++ {
 		filename := "test/os-release." + strconv.Itoa(test)
 		bytes, err := ioutil.ReadFile(filename)
 		if err != nil {
@@ -98,7 +101,7 @@ func TestReadString(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error parsing content of '%v': %v", filename, err)
 		} else {
-			for key, value := range expectedResults[test] {
+			for key, value := range results[test] {
 				if osrelease[key] != value {
 					t.Errorf("In file 'test/os-release.%v', Read() returned '%v' = '%v', should be '%v'", test, key, osrelease[key], value)
 				}


### PR DESCRIPTION
## Content

On one of my [projects](https://github.com/devbuddy/devbuddy) I've happen to need to parse the release of an os and I didn't wanted to parse manually myself `os-release` configuration

I've discovered your project but for a matter of testing I'm interested of having a `ReadString` that would let me inject test cases without needing to use the file system.

## Proposition

This PR is introducing `ReadString` and adds the corresponding tests.

